### PR TITLE
[examples] Remove required environment variables from nx example deploy button

### DIFF
--- a/examples/nx/README.md
+++ b/examples/nx/README.md
@@ -28,7 +28,7 @@ You can choose from one of the following methods to use this repository:
 
 Deploy the example using [Vercel](https://vercel.com?utm_source=github&utm_medium=readme&utm_campaign=vercel-examples):
 
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/git/external?repository-url=https://github.com/vercel/remote-cache/tree/main/examples/nx&project-name=nx-monorepo-with-vercel-cache&output-directory=dist%2Fapps%2Fapp%2F.next&build-command=npx%20nx%20build%20app%20--prod&ignore-command=npx%20nx-ignore%20app&repository-name=nx-monorepo&env=NX_VERCEL_REMOTE_CACHE_TOKEN,NX_VERCEL_REMOTE_CACHE_TEAM&envDescription=Enter%20your%20team%20and%20token%20to%20enable%20Vercel%20Remote%20Caching.)
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/git/external?repository-url=https://github.com/vercel/remote-cache/tree/main/examples/nx&project-name=nx-monorepo-with-vercel-cache&output-directory=dist%2Fapps%2Fapp%2F.next&build-command=npx%20nx%20build%20app%20--prod&ignore-command=npx%20nx-ignore%20app&repository-name=nx-monorepo)
 
 
 ### Start Locally


### PR DESCRIPTION
These are unnecessary in Vercel deployments